### PR TITLE
[WIP] Allow fsType as parameter of CreateVolume requests

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -42,6 +42,7 @@ var (
 
 	volumeTypeKey = "type"
 	encryptedKey  = "encrypted"
+	fsTypeKey     = "fstype"
 )
 
 type controllerService struct {
@@ -96,6 +97,8 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 			}
 			// TODO check if this value has changed?
 			encrypted = encryptedValue
+		case fsTypeKey:
+			// nop, just allow the parameter to be passed
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "invalid parameter key %s", key)
 		}


### PR DESCRIPTION
> What value does this feature bring to end users ?

This is mainly intended to be able to provision XFS-formatted PVCs

> How urgent is the need (nice to have feature or need to have) ?

nice to have

> Does this align with the goals of scaleway-csi ?

I think so?

---

From looking at https://github.com/scaleway/scaleway-csi/blob/2092531de88b8b381724b6202769b4bb33a029d9/driver/diskutils.go#L202 it looks like it will look for a `mkfs.<fsType>` binary and use it

Also from https://github.com/scaleway/scaleway-csi/blob/2092531de88b8b381724b6202769b4bb33a029d9/driver/diskutils.go#L429-L435 we see that resize is technically also already there

and finally https://github.com/scaleway/scaleway-csi/blob/master/Dockerfile#L21-L22 has xfsprogs bundled, so the binary is there already

Marked as WIP because I'm not sure where/how to add tests for this change, nor if that's enough to make this work. Let me know

Thanks