### PR TITLE
feature: LUKS volumes expansion

### DIFF
--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -12,13 +12,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubernetes-csi/csi-test/v5/pkg/sanity"
-	"github.com/scaleway/scaleway-csi/scaleway"
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"golang.org/x/sys/unix"
 	kmount "k8s.io/mount-utils"
 	kexec "k8s.io/utils/exec"
 	utilsio "k8s.io/utils/io"
+
+	"github.com/scaleway/scaleway-csi/scaleway"
 )
 
 type fakeHelper struct {
@@ -526,8 +527,12 @@ func (s *fakeHelper) GetStatfs(path string) (*unix.Statfs_t, error) {
 	}, nil
 }
 
-func (s *fakeHelper) Resize(targetPath string, devicePath string) error {
+func (s *fakeHelper) Resize(targetPath string, devicePath, passphrase string) error {
 	return nil
+}
+
+func (s *fakeHelper) IsEncrypted(devicePath string) (bool, error) {
+	return false, nil
 }
 
 func (s *fakeHelper) EncryptAndOpenDevice(volumeID string, passphrase string) (string, error) {

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -245,7 +245,8 @@ data:
 
 and the following StorageClass:
 ```yaml
-allowVolumeExpansion: false # not yet supported
+# Volume expansion is supported with CSINodeExpandSecret feature gate since v1.25.0 or by default since v1.27.0
+allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -257,6 +258,9 @@ parameters:
   encrypted: "true"
   csi.storage.k8s.io/node-stage-secret-name: "enc-secret"
   csi.storage.k8s.io/node-stage-secret-namespace: "default"
+  # Required for volume expansion
+  csi.storage.k8s.io/node-expand-secret-name: "enc-secret"
+  csi.storage.k8s.io/node-expand-secret-namespace: "default"
 ```
 
 all the PVC created with the StorageClass `scw-bssd-enc` will be encrypted at rest with the passphrase `myawesomepassphrase`.


### PR DESCRIPTION
This feature requires the [CSINodeExpandSecret feature gate](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/) to be enabled, [available since Kubernetes v1.25 and enabled by default since v1.27](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).