### PR TITLE
fix: use better implementation of FormatAndMount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ARG COMMIT_SHA
 ARG BUILD_DATE
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-w -s -X github.com/scaleway/scaleway-csi/driver.driverVersion=${TAG} -X github.com/scaleway/scaleway-csi/driver.buildDate=${BUILD_DATE} -X github.com/scaleway/scaleway-csi/driver.gitCommit=${COMMIT_SHA} " -o scaleway-csi ./cmd/scaleway-csi
 
-FROM alpine:3.18
-RUN apk update && apk add --no-cache e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra cryptsetup ca-certificates && update-ca-certificates
+FROM alpine:3.15
+RUN apk update && apk add --no-cache e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra cryptsetup ca-certificates blkid && update-ca-certificates
 WORKDIR /
 COPY --from=builder /go/src/github.com/scaleway/scaleway-csi/scaleway-csi .
 ENTRYPOINT ["/scaleway-csi"]

--- a/driver/sanity_test.go
+++ b/driver/sanity_test.go
@@ -3,7 +3,6 @@ package driver
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -388,44 +387,6 @@ func (s *fakeHelper) MountToTarget(sourcePath, targetPath, fsType string, mountO
 		block:        strings.HasPrefix(sourcePath, diskByIDPath),
 	}
 	return nil
-}
-
-func (s *fakeHelper) getDeviceType(devicePath string) (string, error) {
-	blkidPath, err := exec.LookPath("blkid")
-	if err != nil {
-		return "", err
-	}
-
-	blkidArgs := []string{"-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", devicePath}
-	blkidOutputBytes, err := exec.Command(blkidPath, blkidArgs...).Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			if exitErr.ExitCode() == 2 {
-				// From man page of blkid:
-				// If the specified token was not found, or no (specified) devices
-				// could be identified, or it is impossible to gather
-				// any information about the device identifiers
-				// or device content an exit code of 2 is returned.
-				return "", nil
-			}
-		}
-		return "", err
-	}
-
-	blkidOutput := string(blkidOutputBytes)
-	blkidOutputLines := strings.Split(blkidOutput, "\n")
-	for _, blkidLine := range blkidOutputLines {
-		if len(blkidLine) == 0 {
-			continue
-		}
-
-		blkidLineSplit := strings.Split(blkidLine, "=")
-		if blkidLineSplit[0] == "TYPE" && len(blkidLineSplit[1]) > 0 {
-			return blkidLineSplit[1], nil
-		}
-	}
-	// TODO real error???
-	return "", nil
 }
 
 func (s *fakeHelper) GetDevicePath(volumeID string) (string, error) {


### PR DESCRIPTION
Add `blkid` package to the Alpine image as the default one cannot be parsed correctly during FormatAndMount.
Temporarily revert back to `alpine:3.15` as newer versions of `xfsprogs` are not supported on Kapsule nodes.