### PR TITLE
fix: typos in error messages

### DIFF
--- a/driver/errors.go
+++ b/driver/errors.go
@@ -15,14 +15,14 @@ var (
 	errFsTypeEmpty                   = errors.New("filesystem type is empty")
 	errDevicePathIsNotDevice         = errors.New("device path does not point on a block device")
 
-	errVolumeCapabilitiesIsNil = errors.New("volume capabilites is nil")
+	errVolumeCapabilitiesIsNil = errors.New("volume capabilities is nil")
 	errVolumeCapabilityIsNil   = errors.New("volume capability is nil")
 	errBothMountBlockVolumes   = errors.New("both mount and block volume type specified")
 	errAccessModeNotSupported  = errors.New("access mode not supported")
 
 	errLimitBytesLessThanRequiredBytes = errors.New("limit size is less than required size")
-	errRequiredBytesLessThanMinimun    = errors.New("required size is less than the minimun size")
-	errLimitBytesLessThanMinimum       = errors.New("limit size is less than the minimun size")
-	errRequiredBytesGreaterThanMaximun = errors.New("required size is greater than the maximum size")
+	errRequiredBytesLessThanMinimum    = errors.New("required size is less than the minimum size")
+	errLimitBytesLessThanMinimum       = errors.New("limit size is less than the minimum size")
+	errRequiredBytesGreaterThanMaximum = errors.New("required size is greater than the maximum size")
 	errLimitBytesGreaterThanMaximum    = errors.New("limit size is greater than the maximum size")
 )

--- a/driver/helpers.go
+++ b/driver/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 )
 
 func getSnapshotIDAndZone(id string) (string, scw.Zone, error) {

--- a/driver/helpers.go
+++ b/driver/helpers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 )
 
 func getSnapshotIDAndZone(id string) (string, scw.Zone, error) {
@@ -180,7 +179,7 @@ func getVolumeRequestCapacity(minSize int64, maxSize int64, capacityRange *csi.C
 	}
 
 	if requiredBytesSet && !limitBytesSet && requiredBytes < minSize {
-		return 0, errRequiredBytesLessThanMinimun
+		return 0, errRequiredBytesLessThanMinimum
 	}
 
 	if limitBytesSet && limitBytes < minSize {
@@ -188,7 +187,7 @@ func getVolumeRequestCapacity(minSize int64, maxSize int64, capacityRange *csi.C
 	}
 
 	if requiredBytesSet && requiredBytes > maxSize {
-		return 0, errRequiredBytesGreaterThanMaximun
+		return 0, errRequiredBytesGreaterThanMaximum
 	}
 
 	if !requiredBytesSet && limitBytesSet && limitBytes > maxSize {

--- a/driver/helpers_test.go
+++ b/driver/helpers_test.go
@@ -583,7 +583,7 @@ func Test_getVolumeRequestCapacity(t *testing.T) {
 				LimitBytes:    0,
 			},
 			res: 0,
-			err: errRequiredBytesLessThanMinimun,
+			err: errRequiredBytesLessThanMinimum,
 		},
 		{
 			capRange: &csi.CapacityRange{
@@ -615,7 +615,7 @@ func Test_getVolumeRequestCapacity(t *testing.T) {
 				LimitBytes:    0,
 			},
 			res: 0,
-			err: errRequiredBytesGreaterThanMaximun,
+			err: errRequiredBytesGreaterThanMaximum,
 		},
 		{
 			capRange: &csi.CapacityRange{


### PR DESCRIPTION
This commit does not only correct the error messages but also the variable naming.

Closes #62